### PR TITLE
Hotfix/null-comparison-fix

### DIFF
--- a/js/h5p.js
+++ b/js/h5p.js
@@ -1435,7 +1435,10 @@ H5P.isObjectEqual = function (aObject, bObject, aStack, bStack) {
   }
 
   if(aObject === null || bObject === null) {
-    return false;
+    if(aObject !== bObject)
+    {
+      return false;
+    }
   }
 
   if(aObject !== aObject) {

--- a/js/h5p.js
+++ b/js/h5p.js
@@ -1435,10 +1435,7 @@ H5P.isObjectEqual = function (aObject, bObject, aStack, bStack) {
   }
 
   if(aObject === null || bObject === null) {
-    if(aObject !== bObject)
-    {
-      return false;
-    }
+    return aObject === bObject;
   }
 
   if(aObject !== aObject) {


### PR DESCRIPTION
- ensures that two null objects are considered equivalent

This change, in conjunction with this [pull request](https://github.com/rider-griffin/h5p-course-presentation/pull/1) is necessary, as we need to consider two null objects to be equivalent. Before the change to course-presentation, this bug would actually allow for a save between two equivalent state objects. 